### PR TITLE
Preparation for supporting GHC 8.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+cabal.sandbox.config
 dist
 dist-newstyle
+.cabal-sandbox
 .ghc.environment.*
 .stack-work

--- a/integer-logarithms.cabal
+++ b/integer-logarithms.cabal
@@ -49,7 +49,7 @@ library
   default-language: Haskell2010
   hs-source-dirs: src
   build-depends:
-    base >= 4.3 && < 4.11,
+    base >= 4.3 && < 4.12,
     array >= 0.3 && < 0.6,
     ghc-prim < 0.6
   if impl(ghc >= 7.10)
@@ -97,7 +97,7 @@ test-suite spec
   build-depends:
     base,
     integer-logarithms,
-    tasty >= 0.10 && < 0.12,
+    tasty >= 0.10 && < 1.1,
     tasty-smallcheck >= 0.8 && < 0.9,
     tasty-quickcheck >= 0.8 && < 0.10,
     tasty-hunit >= 0.9 && < 0.10,


### PR DESCRIPTION
From https://github.com/Bodigrim/integer-logarithms/issues/8#issuecomment-357608673:

> I'd procrastinate with the release, waiting till GHC-8.4 beta/rc1

@phadej, while you continue procrastinating :-), this PR fixes compilation with GHC 8.4.1-alpha1.