### PR TITLE
Bump package version so GHC 8.4.1 changes finish into Hackage

### DIFF
--- a/integer-logarithms.cabal
+++ b/integer-logarithms.cabal
@@ -1,5 +1,5 @@
 name:               integer-logarithms
-version:            1.0.2
+version:            1.0.3
 cabal-version:      >= 1.10
 author:             Daniel Fischer
 copyright:          (c) 2011 Daniel Fischer


### PR DESCRIPTION
Currently cabal file supports GHC 8.4.1, but this is not visible on Hackage.
Could you upload new version of integer-logarithms on Hackage?