### PR TITLE
Add a Travis CI badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 # integer-logarithms
 
+[![Build Status](https://travis-ci.org/Bodigrim/integer-logarithms.svg?branch=master)](https://travis-ci.org/Bodigrim/integer-logarithms)
+
 `Math.NumberTheory.Logarithms` splitted out of [`arithmoi`](http://hackage.haskell.org/package/arithmoi)


### PR DESCRIPTION
Just a cosmetic change, but saves us from having to navigate to the Travis build URL by hand.