### PR TITLE
GHC-9.0 (ghc-bignum) support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+tests: True

--- a/integer-logarithms.cabal
+++ b/integer-logarithms.cabal
@@ -1,7 +1,7 @@
 name:               integer-logarithms
 version:            1.0.3
 x-revision:         2
-cabal-version:      >= 1.10
+cabal-version:      >=1.10
 author:             Daniel Fischer
 copyright:          (c) 2011 Daniel Fischer
 license:            MIT
@@ -11,7 +11,6 @@ build-type:         Simple
 stability:          Provisional
 homepage:           https://github.com/Bodigrim/integer-logarithms
 bug-reports:        https://github.com/Bodigrim/integer-logarithms/issues
-
 synopsis:           Integer logarithms.
 description:
   "Math.NumberTheory.Logarithms" and "Math.NumberTheory.Powers.Integer"
@@ -22,62 +21,78 @@ description:
   additional functions in migrated modules.
 
 category:           Math, Algorithms, Number Theory
-
 tested-with:
-  GHC==7.0.4,
-  GHC==7.2.2,
-  GHC==7.4.2,
-  GHC==7.6.3,
-  GHC==7.8.4,
-  GHC==7.10.3,
-  GHC==8.0.2,
-  GHC==8.2.2,
-  GHC==8.4.4,
-  GHC==8.6.5,
-  GHC==8.8.2,
-  GHC==8.10.2
+    GHC ==7.0.4
+     || ==7.2.2
+     || ==7.4.2
+     || ==7.6.3
+     || ==7.8.4
+     || ==7.10.3
+     || ==8.0.2
+     || ==8.2.2
+     || ==8.4.4
+     || ==8.6.4
+     || ==8.8.3
+     || ==8.10.1
+  , GHCJS ==8.4
 
-extra-source-files  : readme.md changelog.md
+extra-source-files:
+  readme.md
+  changelog.md
+
+flag ghc-bignum
+  description: ghc-bignum
+  default:     True
+  manual:      False
 
 flag integer-gmp
-  description:  integer-gmp or integer-simple
-  default:      True
-  manual:       False
+  description: integer-gmp or integer-simple
+  default:     True
+  manual:      False
 
 flag check-bounds
-  description:  Replace unsafe array operations with safe ones
-  default:      False
-  manual:       True
+  description: Replace unsafe array operations with safe ones
+  default:     False
+  manual:      True
 
 library
   default-language: Haskell2010
-  hs-source-dirs: src
+  hs-source-dirs:   src
   build-depends:
-    base >= 4.3 && < 4.15,
-    array >= 0.3 && < 0.6,
-    ghc-prim < 0.7
+      array     >=0.3 && <0.6
+    , base      >=4.3 && <4.16
+    , ghc-prim  >=0   && <0.8
 
-  if !impl(ghc >= 7.10)
-    build-depends: nats >= 1.1.2 && <1.2
+  if !impl(ghc >=7.10)
+    build-depends: nats >=1.1.2 && <1.2
 
-  if flag(integer-gmp)
+  if flag(ghc-bignum)
     build-depends:
-      integer-gmp < 1.1
+        base        >=4.15
+      , ghc-bignum  >=1.0  && <1.1
+
   else
-    build-depends:
-      integer-simple
+    build-depends: base <4.15
+
+    if flag(integer-gmp)
+      build-depends: integer-gmp <1.1
+
+    else
+      build-depends: integer-simple
 
   exposed-modules:
+    GHC.Integer.Logarithms.Compat
     Math.NumberTheory.Logarithms
     Math.NumberTheory.Powers.Integer
     Math.NumberTheory.Powers.Natural
-    GHC.Integer.Logarithms.Compat
+
   other-extensions:
     BangPatterns
     CPP
     MagicHash
 
-  ghc-options: -O2 -Wall
+  ghc-options:      -O2 -Wall
+
   if flag(check-bounds)
     cpp-options: -DCheckBounds
 
@@ -86,28 +101,30 @@ source-repository head
   location: https://github.com/Bodigrim/integer-logarithms
 
 test-suite spec
-  type:                 exitcode-stdio-1.0
-  hs-source-dirs:       test-suite
-  ghc-options:          -Wall
-  main-is:              Test.hs
-  default-language:     Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test-suite
+  ghc-options:      -Wall
+  main-is:          Test.hs
+  default-language: Haskell2010
   other-extensions:
-    StandaloneDeriving
     FlexibleContexts
     FlexibleInstances
     GeneralizedNewtypeDeriving
     MultiParamTypeClasses
+    StandaloneDeriving
+
   build-depends:
-    base,
-    integer-logarithms,
-    tasty >= 0.10 && < 1.3,
-    tasty-smallcheck >= 0.8 && < 0.9,
-    tasty-quickcheck >= 0.8 && < 0.11,
-    tasty-hunit >= 0.9 && < 0.11,
-    QuickCheck >= 2.10 && < 2.14,
-    smallcheck >= 1.1.3 && < 1.2
-  if !impl(ghc >= 7.10)
-    build-depends: nats >= 1.1 && <1.2
+      base
+    , integer-logarithms
+    , QuickCheck          >=2.14.1 && <2.15
+    , smallcheck          >=1.2    && <1.3
+    , tasty               >=0.10   && <1.4
+    , tasty-hunit         >=0.9    && <0.11
+    , tasty-quickcheck    >=0.8    && <0.11
+    , tasty-smallcheck    >=0.8    && <0.9
+
+  if !impl(ghc >=7.10)
+    build-depends: nats ==1.1.*
 
   other-modules:
     Math.NumberTheory.LogarithmsTests

--- a/src/Math/NumberTheory/Logarithms.hs
+++ b/src/Math/NumberTheory/Logarithms.hs
@@ -44,6 +44,10 @@ import Data.Bits
 import Data.Array.Unboxed
 import Numeric.Natural
 
+#ifdef MIN_VERSION_ghc_bignum
+import qualified GHC.Num.Natural as BN
+#endif
+
 import GHC.Integer.Logarithms.Compat
 #if MIN_VERSION_base(4,8,0) && defined(MIN_VERSION_integer_gmp)
 import GHC.Integer.GMP.Internals (Integer (..))
@@ -316,11 +320,15 @@ fromNatural :: Num a => Natural -> a
 fromNatural = fromIntegral
 
 naturalLog2# :: Natural -> Int#
+#ifdef MIN_VERSION_ghc_bignum
+naturalLog2# n = word2Int# (BN.naturalLog2# n)
+#else
 #if MIN_VERSION_base(4,8,0) && defined(MIN_VERSION_integer_gmp)
 naturalLog2# (NatS# b) = wordLog2# b
 naturalLog2# (NatJ# n) = integerLog2# (Jp# n)
 #else
 naturalLog2# n = integerLog2# (toInteger n)
+#endif
 #endif
 
 #if __GLASGOW_HASKELL__ < 707

--- a/test-suite/Math/NumberTheory/LogarithmsTests.hs
+++ b/test-suite/Math/NumberTheory/LogarithmsTests.hs
@@ -68,7 +68,7 @@ naturalLog2Property (Positive n) = 2 ^ l <= n && 2 ^ (l + 1) > n
 naturalLog2HugeProperty :: Huge (Positive Natural) -> Bool
 naturalLog2HugeProperty (Huge (Positive n)) = 2 ^ l <= n && 2 ^ (l + 1) > n
   where
-    l = fromIntegral $ naturalLog2 n
+    l = naturalLog2 n
 
 -- | Check that 'naturalLog10' returns the largest natural @l@ such that 10 ^ @l@ <= @n@ and 10 ^ (@l@+1) > @n@.
 naturalLog10Property :: Positive Natural -> Bool


### PR DESCRIPTION
Blocked on https://gitlab.haskell.org/ghc/ghc/-/issues/18509

We probably should clean up the types to be the same as ghc-bignum (e.g. returning `Word` from logarithms), but that will be breaking change so better done after GHC-9.0 compatible release.