### PR TITLE
Remove unused `ghc-prim` dependency

### DIFF
--- a/integer-logarithms.cabal
+++ b/integer-logarithms.cabal
@@ -54,7 +54,6 @@ library
   build-depends:
       array     >=0.5.3.0  && <0.6
     , base      >=4.12.0.0 && <4.22
-    , ghc-prim  <0.14
 
   if !impl(ghc >=7.10)
     build-depends: nats >=1.1.2 && <1.2


### PR DESCRIPTION
It isn't used anywhere and it's not recommended to depend on it either.